### PR TITLE
DPO-4628: Include authorities.xml in PETI NeTEx zip exports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/src/main/java/fi/digitraffic/ura/kooste/http/KoosteHttpClient.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/http/KoosteHttpClient.java
@@ -19,12 +19,17 @@ public class KoosteHttpClient {
     private static final Logger logger = LoggerFactory.getLogger(KoosteHttpClient.class);
 
     /**
-     *  GET resource in URI and stream contents into ZIP-archive.
+     * GET resource from URI and stream contents into a ZIP archive.
+     *
+     * <p><strong>Important:</strong> The primary entry (fileName) is always the first zip entry.
+     * The URA backend (NetexFileStopPlaceLoader) reads only the first entry from the zip.</p>
      *
      * @param uri URI to download
-     * @param fileName Filename inside ZIP-archive
+     * @param destination File to write the ZIP to
+     * @param fileName Primary filename inside the ZIP archive
+     * @param extraEntries Additional entries to include in the ZIP after the primary entry (may be null or empty)
      */
-    public static void get(URI uri, File destination, String fileName) throws IOException, InterruptedException {
+    public static void get(URI uri, File destination, String fileName, Map<String, byte[]> extraEntries) throws IOException, InterruptedException {
         try (HttpClient client = HttpClient.newHttpClient()) {
             HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
             try {
@@ -44,6 +49,15 @@ public class KoosteHttpClient {
                         zipOutputStream.write(buffer, 0, bytesRead);
                     }
                     zipOutputStream.closeEntry();
+
+                    if (extraEntries != null) {
+                        for (Map.Entry<String, byte[]> extra : extraEntries.entrySet()) {
+                            ZipEntry extraEntry = new ZipEntry(extra.getKey());
+                            zipOutputStream.putNextEntry(extraEntry);
+                            zipOutputStream.write(extra.getValue());
+                            zipOutputStream.closeEntry();
+                        }
+                    }
                 }
                 logger.info("File {} downloaded and archived successfully to: {}", uri, destination);
             } catch (Exception e) {

--- a/src/main/java/fi/digitraffic/ura/kooste/publications/PublicationsService.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/publications/PublicationsService.java
@@ -359,20 +359,20 @@ public class PublicationsService {
         return cloudFrontUrl.formatted(objectName);
     }
 
-    public void downloadResource(Publisher.DownloadPublisher publisher) {
-        downloadResource(publisher, publisher.getURI(), true, Map.of());
-    }
-
-    public void downloadResource(Publisher.DownloadPublisher publisher, URI uri, boolean archive, Map<String, String> headers) {
-        downloadResource(publisher, uri, archive, headers, new HashMap<>());
+    public void downloadResource(Publisher.DownloadPublisher publisher, Map<String, byte[]> extraZipEntries) {
+        downloadResource(publisher, publisher.getURI(), true, Map.of(), new HashMap<>(), extraZipEntries);
     }
 
     public void downloadResource(Publisher.DownloadPublisher publisher, URI uri, boolean archive, Map<String, String> headers, HashMap<String, String> metadata) {
+        downloadResource(publisher, uri, archive, headers, metadata, null);
+    }
+
+    public void downloadResource(Publisher.DownloadPublisher publisher, URI uri, boolean archive, Map<String, String> headers, HashMap<String, String> metadata, Map<String, byte[]> extraZipEntries) {
         File file = null;
         try {
             file =  File.createTempFile(TEMP_FILE_PREFIX, ".zip");
             if (archive) {
-                KoosteHttpClient.get(uri, file, NETEX_ARCHIVE_FILENAME);
+                KoosteHttpClient.get(uri, file, NETEX_ARCHIVE_FILENAME, extraZipEntries);
             } else {
                 KoosteHttpClient.get(uri, file, headers);
             }

--- a/src/main/java/fi/digitraffic/ura/kooste/publications/model/Publisher.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/publications/model/Publisher.java
@@ -21,8 +21,8 @@ public class Publisher {
 
     public final static List<IPublisher> PUBLISHERS = List.of(
         new S3Publisher("URA", KOOSTE_EXPORT_PATTERN, S3_UTTU_INPUT_PREFIX, PublisherFormat.NETEX, true),
-        new DownloadPublisher("PETI", PETI_NETEX_ALL_PATTERN, S3_PETI_INPUT_PREFIX, PublisherFormat.NETEX, "kooste.tasks.download.url.peti.all", "all", "PETI-NeTEx-all-{timestamp}.zip"),
-        new DownloadPublisher("PETI", PETI_NETEX_RAIL_PATTERN, S3_PETI_INPUT_PREFIX, PublisherFormat.NETEX, "kooste.tasks.download.url.peti.rail", "rail", "PETI-NeTEx-rail-{timestamp}.zip"),
+        new DownloadPublisher("PETI", PETI_NETEX_ALL_PATTERN, S3_PETI_INPUT_PREFIX, PublisherFormat.NETEX, "kooste.tasks.download.url.peti.all", "all", "PETI-NeTEx-all-{timestamp}.zip", true),
+        new DownloadPublisher("PETI", PETI_NETEX_RAIL_PATTERN, S3_PETI_INPUT_PREFIX, PublisherFormat.NETEX, "kooste.tasks.download.url.peti.rail", "rail", "PETI-NeTEx-rail-{timestamp}.zip", true),
         new S3Publisher("PETI", PETI_GTFS_ALL_EXPORT_PATTERN, S3_VACO_INPUT_PREFIX, PublisherFormat.GTFS, false)
     );
 
@@ -54,7 +54,8 @@ public class Publisher {
     }
 
     public record DownloadPublisher(String name, Pattern exportPattern, String inputPrefix,
-                                    PublisherFormat format, String urlProperty, String exportType, String exportTemplate) implements IPublisher {
+                                    PublisherFormat format, String urlProperty, String exportType, String exportTemplate,
+                                    boolean includeAuthorities) implements IPublisher {
 
         @Override
         public boolean mergeContents() {

--- a/src/main/java/fi/digitraffic/ura/kooste/scheduled/DownloadTask.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/scheduled/DownloadTask.java
@@ -2,6 +2,7 @@ package fi.digitraffic.ura.kooste.scheduled;
 
 import fi.digitraffic.ura.kooste.publications.PublicationsService;
 import fi.digitraffic.ura.kooste.publications.model.Publisher;
+import fi.digitraffic.ura.kooste.vaco.AuthoritiesDownloadService;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -9,18 +10,22 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 
 @ApplicationScoped
 public class DownloadTask {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DownloadTask.class);
 
     private final PublicationsService publicationsService;
+    private final AuthoritiesDownloadService authoritiesDownloadService;
 
     @ConfigProperty(name = "kooste.tasks.download.enabled", defaultValue = "true")
     boolean enabled;
 
-    public DownloadTask(PublicationsService publicationsService) {
+    public DownloadTask(PublicationsService publicationsService, AuthoritiesDownloadService authoritiesDownloadService) {
         this.publicationsService = publicationsService;
+        this.authoritiesDownloadService = authoritiesDownloadService;
     }
 
     @Scheduled(cron="${kooste.tasks.download.schedule1}", timeZone = "Europe/Helsinki")
@@ -31,10 +36,20 @@ public class DownloadTask {
             logger.info("Download task is disabled. Skipping execution.");
             return;
         }
+
+        // Attempt to fetch authorities.xml. If it fails, we can still proceed with the download of other resources.
+        // Rae needs stops data so we don't want to fail the entire task if authorities.xml cannot be fetched.
+        byte[] authoritiesXml = authoritiesDownloadService.fetchAuthoritiesXml();
+        Map<String, byte[]> extraZipEntries = authoritiesXml != null
+            ? Map.of("authorities.xml", authoritiesXml)
+            : null;
+
+        // Iterate through publishers and attempt to download resources. If authorities.xml was successfully fetched, it will be included in the download for publishers that require it.
         Publisher.PUBLISHERS.forEach(publisher -> {
             if (publisher instanceof Publisher.DownloadPublisher downloadPublisher) {
                 logger.info("Attempting to download url {}", downloadPublisher.getURI());
-                publicationsService.downloadResource(downloadPublisher);
+                Map<String, byte[]> entries = downloadPublisher.includeAuthorities() ? extraZipEntries : null;
+                publicationsService.downloadResource(downloadPublisher, entries);
             }
         });
     }

--- a/src/main/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadService.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadService.java
@@ -1,0 +1,62 @@
+package fi.digitraffic.ura.kooste.vaco;
+
+import fi.digitraffic.ura.kooste.http.KoosteHttpClient;
+import io.quarkus.oidc.client.Tokens;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Map;
+
+@ApplicationScoped
+public class AuthoritiesDownloadService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthoritiesDownloadService.class);
+
+    private static final String AUTHORITIES_PATH = "/api/exports/netex/authorities";
+
+    private final URI vacoBaseUri;
+    private final Tokens tokens;
+
+    public AuthoritiesDownloadService(
+        @ConfigProperty(name = "kooste.tasks.vaco.url") String vacoUrl,
+        Tokens tokens
+    ) {
+        String base = vacoUrl.endsWith("/") ? vacoUrl.substring(0, vacoUrl.length() - 1) : vacoUrl;
+        this.vacoBaseUri = URI.create(base);
+        this.tokens = tokens;
+    }
+
+    /**
+     * Downloads authorities.xml from VACO. Returns the raw XML bytes, or null if the download fails.
+     */
+    public byte[] fetchAuthoritiesXml() {
+        try {
+            URI uri = resolveAuthoritiesUri();
+            Map<String, String> headers = getHeaders();
+            byte[] response = KoosteHttpClient.get(uri, headers);
+            if (response.length == 0) {
+                logger.warn("VACO returned empty authorities response");
+                return null;
+            }
+            logger.info("Downloaded authorities.xml ({} bytes)", response.length);
+            return response;
+        } catch (Exception e) {
+            logger.warn("Failed to download authorities.xml from VACO, PETI NeTEx zip will be published without it", e);
+            return null;
+        }
+    }
+
+    URI resolveAuthoritiesUri() {
+        return vacoBaseUri.resolve(AUTHORITIES_PATH);
+    }
+
+    private Map<String, String> getHeaders() {
+        return Map.of(
+            "Authorization", String.format("Bearer %s", tokens.getAccessToken()),
+            "Accept", "application/xml"
+        );
+    }
+}

--- a/src/main/java/fi/digitraffic/ura/kooste/vaco/VacoTask.java
+++ b/src/main/java/fi/digitraffic/ura/kooste/vaco/VacoTask.java
@@ -60,7 +60,8 @@ public class VacoTask {
             Publisher.PublisherFormat.GTFS,
             "kooste.tasks.vaco.download.url.gtfs",
             "all",
-            "PETI-GTFS-all-{timestamp}.zip");
+            "PETI-GTFS-all-{timestamp}.zip",
+            false);
 
     private final PublicationsService publicationsService;
     private final String koosteEnvironment;

--- a/src/test/java/fi/digitraffic/ura/kooste/http/KoosteHttpClientTest.java
+++ b/src/test/java/fi/digitraffic/ura/kooste/http/KoosteHttpClientTest.java
@@ -1,0 +1,119 @@
+package fi.digitraffic.ura.kooste.http;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class KoosteHttpClientTest {
+
+    private static HttpServer server;
+    private static URI baseUri;
+
+    @BeforeAll
+    static void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/stops", exchange -> {
+            byte[] body = "<stops>test</stops>".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.getResponseBody().close();
+        });
+        server.createContext("/error", exchange -> {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.getResponseBody().close();
+        });
+        server.start();
+        baseUri = URI.create("http://localhost:" + server.getAddress().getPort());
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void createsZipWithPrimaryEntryOnly(@TempDir File tempDir) throws Exception {
+        File destination = new File(tempDir, "output.zip");
+
+        KoosteHttpClient.get(baseUri.resolve("/stops"), destination, "stops.xml", null);
+
+        List<String> entries = zipEntryNames(destination);
+        assertThat(entries.size(), is(1));
+        assertThat(entries.get(0), is(equalTo("stops.xml")));
+        assertThat(zipEntryContent(destination, "stops.xml"), is(equalTo("<stops>test</stops>")));
+    }
+
+    @Test
+    void createsZipWithExtraEntries(@TempDir File tempDir) throws Exception {
+        File destination = new File(tempDir, "output.zip");
+        byte[] authoritiesXml = "<authorities>data</authorities>".getBytes(StandardCharsets.UTF_8);
+
+        KoosteHttpClient.get(
+            baseUri.resolve("/stops"),
+            destination,
+            "stops.xml",
+            Map.of("authorities.xml", authoritiesXml));
+
+        List<String> entries = zipEntryNames(destination);
+        assertThat(entries.size(), is(2));
+        // stops.xml must be first — URA backend (NetexFileStopPlaceLoader) reads only the first zip entry
+        assertThat(entries.get(0), is(equalTo("stops.xml")));
+        assertThat(entries.get(1), is(equalTo("authorities.xml")));
+        assertThat(zipEntryContent(destination, "stops.xml"), is(equalTo("<stops>test</stops>")));
+        assertThat(zipEntryContent(destination, "authorities.xml"), is(equalTo("<authorities>data</authorities>")));
+    }
+
+    @Test
+    void throwsOnHttpError(@TempDir File tempDir) {
+        File destination = new File(tempDir, "output.zip");
+
+        assertThrows(RuntimeException.class, () ->
+            KoosteHttpClient.get(baseUri.resolve("/error"), destination, "stops.xml", null));
+    }
+
+    private static List<String> zipEntryNames(File zipFile) throws IOException {
+        List<String> names = new ArrayList<>();
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                names.add(entry.getName());
+                zis.closeEntry();
+            }
+        }
+        return names;
+    }
+
+    private static String zipEntryContent(File zipFile, String entryName) throws IOException {
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.getName().equals(entryName)) {
+                    String content = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                    zis.closeEntry();
+                    return content;
+                }
+                zis.closeEntry();
+            }
+        }
+        throw new AssertionError("Entry not found: " + entryName);
+    }
+}

--- a/src/test/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadServiceLocalIT.java
+++ b/src/test/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadServiceLocalIT.java
@@ -1,0 +1,95 @@
+package fi.digitraffic.ura.kooste.vaco;
+
+import fi.digitraffic.ura.kooste.http.KoosteHttpClient;
+import fi.digitraffic.ura.kooste.publications.model.Publisher;
+import io.quarkus.oidc.client.Tokens;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Manual smoke test for verifying AuthoritiesDownloadService against a real VACO instance.
+ * Skipped by default — only runs when a bearer token is explicitly provided.
+ *
+ * <p>Prerequisites:</p>
+ * <ul>
+ *   <li>VACO backend running locally on http://localhost:8080</li>
+ *   <li>A valid Azure AD bearer token for the VACO API</li>
+ * </ul>
+ * 
+ * <p>To get a token, copy it for example from browser DevTools (Network tab → any VACO API request →
+ * Authorization header)</p>
+ *
+ * <p>Run with:</p>
+ * <pre>
+ *   mvn test -Dtest=AuthoritiesDownloadServiceLocalIT -Dtest.vaco.token=eyJ...
+ * </pre>
+ *
+ * <p>Output zip is saved to {@code target/test-output/PETI-NeTEx-all-test.zip} for manual inspection.</p>
+ */
+@QuarkusTest
+@EnabledIfSystemProperty(named = "test.vaco.token", matches = ".+")
+class AuthoritiesDownloadServiceLocalIT {
+
+    @Inject
+    AuthoritiesDownloadService authoritiesDownloadService;
+
+    @InjectMock
+    Tokens tokens;
+
+    /**
+     * End-to-end test: downloads PETI NeTEx stops from peti-dev AND authorities.xml from VACO,
+     * creates a zip containing both, and verifies the zip entries.
+     *
+     * <p>Requires VACO running locally on port 8080. Uses peti-dev.fintraffic.fi for stops data.</p>
+     */
+    @Test
+    void createsPetiZipWithAuthorities(@TempDir File tempDir) throws Exception {
+        when(tokens.getAccessToken()).thenReturn(System.getProperty("test.vaco.token"));
+
+        // 1. Download authorities.xml from VACO
+        byte[] authoritiesXml = authoritiesDownloadService.fetchAuthoritiesXml();
+        assertThat("authorities.xml download failed", authoritiesXml, is(notNullValue()));
+
+        // 2. Download PETI stops and create zip with authorities.xml included
+        URI petiUri = URI.create("https://digitraffic-tis-peti-dev.aws.fintraffic.cloud/api/fintraffic/v1/stops");
+        File zipFile = new File(tempDir, "PETI-NeTEx-all-test.zip");
+        KoosteHttpClient.get(petiUri, zipFile, Publisher.NETEX_ARCHIVE_FILENAME, Map.of("authorities.xml", authoritiesXml));
+
+        // 3. Verify zip contains both entries
+        assertThat("Zip file was not created", zipFile.exists(), is(true));
+        try (ZipFile zip = new ZipFile(zipFile)) {
+            ZipEntry stopsEntry = zip.getEntry("stops.xml");
+            assertThat("stops.xml missing from zip", stopsEntry, is(notNullValue()));
+            assertThat("stops.xml should not be empty", stopsEntry.getSize() != 0, is(true));
+
+            ZipEntry authoritiesEntry = zip.getEntry("authorities.xml");
+            assertThat("authorities.xml missing from zip", authoritiesEntry, is(notNullValue()));
+
+            String authoritiesContent = new String(zip.getInputStream(authoritiesEntry).readAllBytes());
+            assertThat(authoritiesContent, containsString("<PublicationDelivery"));
+        }
+
+        // 4. Copy zip to target/ for manual inspection
+        File outputDir = new File("target/test-output");
+        outputDir.mkdirs();
+        File savedZip = new File(outputDir, "PETI-NeTEx-all-test.zip");
+        java.nio.file.Files.copy(zipFile.toPath(), savedZip.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        System.out.println("Zip saved to: " + savedZip.getAbsolutePath());
+    }
+}

--- a/src/test/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadServiceTest.java
+++ b/src/test/java/fi/digitraffic/ura/kooste/vaco/AuthoritiesDownloadServiceTest.java
@@ -1,0 +1,39 @@
+package fi.digitraffic.ura.kooste.vaco;
+
+import io.quarkus.oidc.client.Tokens;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthoritiesDownloadServiceTest {
+
+    @Test
+    void resolvesAuthoritiesEndpointCorrectly() {
+        AuthoritiesDownloadService service = new AuthoritiesDownloadService(
+            "https://vaco.example.com",
+            null // tokens not needed for URI resolution test
+        );
+        assertThat(
+            service.resolveAuthoritiesUri().toString(),
+            is(equalTo("https://vaco.example.com/api/exports/netex/authorities"))
+        );
+    }
+    
+    @Test
+    void returnsNullWhenTokenFails() {
+        Tokens tokens = mock(Tokens.class);
+        when(tokens.getAccessToken()).thenThrow(new RuntimeException("token refresh failed"));
+
+        AuthoritiesDownloadService service = new AuthoritiesDownloadService(
+            "https://vaco.example.com",
+            tokens
+        );
+
+        assertThat(service.fetchAuthoritiesXml(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
[AuthoritiesDownloadServiceLocalIT.java](https://github.com/tmfg/digitraffic-tis-editors-ura-kooste/compare/DPO-4628/add-authorities-xml-to-peti-netex?expand=1#diff-7fdd647ce49e0a1f4673ff857e5de5ea40231da482f98e440ea77f4a03151026) can be used locally to test if needed.
Related VACO PR: https://github.com/tmfg/digitraffic-tis-vaco/pull/508